### PR TITLE
Mark the layout "dirty" on focus hook change, so it updates

### DIFF
--- a/src/Kaleidoscope/Colormap.cpp
+++ b/src/Kaleidoscope/Colormap.cpp
@@ -29,6 +29,7 @@ namespace kaleidoscope {
 uint16_t ColormapEffect::map_base_;
 uint8_t ColormapEffect::max_layers_;
 uint8_t ColormapEffect::last_highest_layer_;
+bool ColormapEffect::dirty_ = false;
 
 void ColormapEffect::setup(void) {
   Kaleidoscope.use(&::EEPROMSettings, &::LEDPaletteTheme);
@@ -49,9 +50,10 @@ void ColormapEffect::onActivate(void) {
 }
 
 void ColormapEffect::update(void) {
-  if (Layer.top() == last_highest_layer_)
+  if (Layer.top() == last_highest_layer_ && !dirty_)
     return;
 
+  dirty_ = false;
   onActivate();
 }
 
@@ -66,6 +68,9 @@ bool ColormapEffect::focusHook(const char *command) {
 }
 
 bool ColormapEffect::focusHookLayerwise(const char *command) {
+  // We might set dirty unneccessarily sometimes, if using this hook to read
+  // The usual case for this hook is updating though, so this is probably okay
+  dirty_ = true;
   return ::LEDPaletteTheme.themeLayerFocusHandler(command, PSTR("colormap.layer"),
                                                   map_base_, max_layers_);
 }

--- a/src/Kaleidoscope/Colormap.h
+++ b/src/Kaleidoscope/Colormap.h
@@ -41,6 +41,7 @@ class ColormapEffect : public LEDMode {
   static uint8_t last_highest_layer_;
   static uint8_t max_layers_;
   static uint16_t map_base_;
+  static bool dirty_;
 };
 }
 


### PR DESCRIPTION
Previously, when using the Focus hook to change the LED Colormap, one
would need to trigger a refresh by switching layers or toggling LED themes