### PR TITLE
Migrate to the onFocusEvent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ color map per-layer. This means that we can set up a map of colors for each key,
 on a per-layer basis, and whenever a layer becomes active, the color map for
 that layer is applied. Colors are picked from a 16-color palette, provided by
 the [LED-Palette-Theme][plugin:l-p-t] plugin. The color map is stored in
-`EEPROM`, and can be easily changed via the [Focus][plugin:focus] plugin, which
-also provides palette editing capabilities.
+`EEPROM`, and can be easily changed via the [FocusSerial][plugin:focusserial]
+plugin, which also provides palette editing capabilities.
 
- [plugin:focus]: https://github.com/keyboardio/Kaleidoscope-Focus
+ [plugin:focusserial]: https://github.com/keyboardio/Kaleidoscope-FocusSerial
  [plugin:l-p-t]: https://github.com/keyboardio/Kaleidoscope-LED-Palette-Theme
 
 ## Using the extension
@@ -29,7 +29,7 @@ register the `Focus` hooks, and it will do the rest.
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-Colormap.h>
-#include <Kaleidoscope-Focus.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include <Kaleidoscope-LED-Palette-Theme.h>
 
 KALEIDOSCOPE_INIT_PLUGINS(EEPROMSettings,
@@ -41,10 +41,6 @@ void setup(void) {
   Kaleidoscope.setup();
 
   ColormapEffect.max_layers(1);
-  Focus.addHook(FOCUS_HOOK_LEDPALETTETHEME);
-  Focus.addHook(FOCUS_HOOK_COLORMAP);
-
-  EEPROMSettings.seal();
 }
 ```
 
@@ -59,9 +55,6 @@ The extension provides an `ColormapEffect` singleton object, with a single metho
 
 ## Focus commands
 
-The plugin provides a single `Focus` hook, `FOCUS_HOOK_COLORMAP`, implementing
-the following command:
-
 ### `colormap.map`
 
 > Without arguments, prints the color map: palette indexes for all layers.
@@ -74,7 +67,7 @@ the following command:
 ## Dependencies
 
 * [Kaleidoscope-EEPROM-Settings](https://github.com/keyboardio/Kaleidoscope-EEPROM-Settings)
-* [Kaleidoscope-Focus](https://github.com/keyboardio/Kaleidoscope-Focus)
+* [Kaleidoscope-FocusSerial](https://github.com/keyboardio/Kaleidoscope-FocusSerial)
 * [Kaleidoscope-LED-Palette-Theme](https://github.com/keyboardio/Kaleidoscope-LED-Palette-Theme)
 
 ## Further reading

--- a/examples/Colormap/Colormap.ino
+++ b/examples/Colormap/Colormap.ino
@@ -18,7 +18,7 @@
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-EEPROM-Settings.h>
 #include <Kaleidoscope-Colormap.h>
-#include <Kaleidoscope-Focus.h>
+#include <Kaleidoscope-FocusSerial.h>
 #include <Kaleidoscope-LED-Palette-Theme.h>
 
 // *INDENT-OFF*
@@ -53,8 +53,6 @@ void setup() {
   Kaleidoscope.setup();
   ColormapEffect.max_layers(1);
   ColormapEffect.activate();
-
-  EEPROMSettings.seal();
 }
 
 void loop() {

--- a/src/Kaleidoscope/Colormap.cpp
+++ b/src/Kaleidoscope/Colormap.cpp
@@ -21,14 +21,13 @@
 #include <EEPROM.h>
 
 #include <Kaleidoscope-EEPROM-Settings.h>
-#include <Kaleidoscope-Focus.h>
+#include <Kaleidoscope-FocusSerial.h>
 
 namespace kaleidoscope {
 
 uint16_t ColormapEffect::map_base_;
 uint8_t ColormapEffect::max_layers_;
 uint8_t ColormapEffect::last_highest_layer_;
-bool ColormapEffect::dirty_ = false;
 
 void ColormapEffect::max_layers(uint8_t max_) {
   if (map_base_ != 0)
@@ -45,10 +44,9 @@ void ColormapEffect::onActivate(void) {
 }
 
 void ColormapEffect::update(void) {
-  if (Layer.top() == last_highest_layer_ && !dirty_)
+  if (Layer.top() == last_highest_layer_)
     return;
 
-  dirty_ = false;
   onActivate();
 }
 
@@ -57,17 +55,9 @@ void ColormapEffect::refreshAt(byte row, byte col) {
     ::LEDPaletteTheme.refreshAt(map_base_, last_highest_layer_, row, col);
 }
 
-bool ColormapEffect::focusHook(const char *command) {
-  return ::LEDPaletteTheme.themeFocusHandler(command, PSTR("colormap.map"),
-         map_base_, max_layers_);
-}
-
-bool ColormapEffect::focusHookLayerwise(const char *command) {
-  // We might set dirty unneccessarily sometimes, if using this hook to read
-  // The usual case for this hook is updating though, so this is probably okay
-  dirty_ = true;
-  return ::LEDPaletteTheme.themeLayerFocusHandler(command, PSTR("colormap.layer"),
-         map_base_, max_layers_);
+EventHandlerResult ColormapEffect::onFocusEvent(const char *command) {
+  return ::LEDPaletteTheme.themeFocusEvent(command, PSTR("colormap.map"),
+                                          map_base_, max_layers_);
 }
 
 }

--- a/src/Kaleidoscope/Colormap.h
+++ b/src/Kaleidoscope/Colormap.h
@@ -27,8 +27,7 @@ class ColormapEffect : public LEDMode {
 
   void max_layers(uint8_t max_);
 
-  static bool focusHook(const char *command);
-  static bool focusHookLayerwise(const char *command);
+  EventHandlerResult onFocusEvent(const char *command);
 
  protected:
   void onActivate(void) final;
@@ -39,14 +38,7 @@ class ColormapEffect : public LEDMode {
   static uint8_t last_highest_layer_;
   static uint8_t max_layers_;
   static uint16_t map_base_;
-  static bool dirty_;
 };
 }
 
 extern kaleidoscope::ColormapEffect ColormapEffect;
-
-#define FOCUS_HOOK_COLORMAP FOCUS_HOOK(ColormapEffect.focusHook,  \
-                                       "colormap.map")
-
-#define FOCUS_HOOK_COLORMAP_LAYER FOCUS_HOOK(ColormapEffect.focusHookLayerwise, \
-                                             "colormap.layer")


### PR DESCRIPTION
Migrate from the old `Focus` API to `onFocusEvent` provided by Kaleidoscope core.

As a side-effect, remove the `colormap.layer` command, which was a workaround for a Chrysalis bug fixed since.

Depends on keyboardio/Kaleidoscope-LED-Palette-Theme#7.